### PR TITLE
Add PETROCAF master orchestrator execution template and README reference

### DIFF
--- a/PETROCAF_MASTER_ORCHESTRATOR_TEMPLATE.md
+++ b/PETROCAF_MASTER_ORCHESTRATOR_TEMPLATE.md
@@ -1,0 +1,100 @@
+# PETROCAF Master Orchestrator — Execution Template
+
+Use this template to structure EPC and construction workflow responses for practical execution, risk control, and commercial clarity.
+
+## 1) Task Classification
+- Select one:
+  - Tender Analysis
+  - Pricing / Estimation
+  - Manpower / HR Data
+  - Excel Audit
+  - Technical Proposal
+  - Client Communication
+  - HSE
+  - QA/QC
+  - Planning / Scheduling
+  - Procurement / Vendor Evaluation
+  - Translation
+  - Reporting
+  - Multi-Domain Composite Task
+
+## 2) Objective
+- State the deliverable in one sentence.
+- Clarify whether the output is internal or client-facing.
+
+## 3) Inputs Received
+- List all files, clauses, assumptions, and constraints actually provided.
+- Tag each item with:
+  - [CONFIRMED]
+  - [EXTRACTED]
+
+## 4) Missing Inputs
+- Explicitly list unknowns and blockers with labels:
+  - [MISSING]
+  - [NOT PROVIDED]
+  - [REQUIRES VERIFICATION]
+  - [LOW CONFIDENCE]
+
+## 5) Recommended Work Sequence
+For multi-domain requests, use stage-based execution.
+
+Example:
+1. Stage 1 — Document extraction
+2. Stage 2 — Tender analysis
+3. Stage 3 — Pricing logic
+4. Stage 4 — Technical proposal drafting
+5. Stage 5 — Client submission communication
+
+For each stage, define:
+- Owner / next agent
+- Inputs required
+- Output expected
+- Go / no-go criteria
+
+## 6) Immediate First Output
+Provide a usable first deliverable immediately, such as:
+- Tender risk register skeleton
+- Pricing BOQ validation sheet structure
+- Clarification query list to client
+- Technical proposal section framework
+
+## 7) Next Best Agent(s)
+If handoff is required, use this exact format:
+
+- **Task Type:**
+- **Objective:**
+- **Inputs Available:**
+- **Missing Inputs:**
+- **Output Produced So Far:**
+- **What the next agent should do:**
+
+## 8) Notes / Risks
+List practical execution and commercial risks with labels:
+- [CRITICAL]
+- [HIGH RISK]
+- [MEDIUM RISK]
+- [LOW RISK]
+- [ACTION REQUIRED]
+
+---
+
+## Output Discipline Checklist
+Before finalizing, confirm:
+- No fabricated data, references, pricing, or quantities.
+- Confirmed vs inferred vs assumed are clearly separated.
+- Ambiguities and contractual traps are identified.
+- Output is decision-useful and executable.
+- Response is concise, structured, and contractor-grade.
+
+## Fast Response Skeleton
+
+```text
+1. Task Classification
+2. Objective
+3. Inputs Received
+4. Missing Inputs
+5. Recommended Work Sequence
+6. Immediate First Output
+7. Next Best Agent(s)
+8. Notes / Risks
+```

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Rules:
 Final goal:
 Same slide, same content, same layout, but rebuilt as a high-quality realistic 3D.
 
+---
+
+Additional internal reference:
+- `PETROCAF_MASTER_ORCHESTRATOR_TEMPLATE.md`: structured workflow and response template for PETROCAF master orchestration tasks.


### PR DESCRIPTION
### Motivation
- Provide a concise, repeatable orchestration template to standardize PETROCAF multi-domain task handling, handoffs, and risk labeling for EPC workflows.
- Improve discoverability of the orchestration guidance by referencing it from the repository `README.md` so contributors can follow the same stage-based process.

### Description
- Added a new reference file `PETROCAF_MASTER_ORCHESTRATOR_TEMPLATE.md` containing task classification, required labels, staged work sequence, handoff format, risk tags, and an output-discipline checklist.
- Updated `README.md` to include a direct internal reference to `PETROCAF_MASTER_ORCHESTRATOR_TEMPLATE.md` for discoverability.
- No changes were made to existing Python logic or behavior in `smart_allocation.py`.

### Testing
- Ran `python -m py_compile smart_allocation.py` to validate Python syntax, and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30f57d9a88324909898c9984a60d6)